### PR TITLE
Resource amount display for building

### DIFF
--- a/Assets/UI/InfoWidgets/ResourcesOverlay.tscn
+++ b/Assets/UI/InfoWidgets/ResourcesOverlay.tscn
@@ -10,6 +10,7 @@ anchors_preset = 0
 offset_right = 20.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+mouse_filter = 1
 script = ExtResource("1_24h02")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]

--- a/Assets/UI/TabWidgets/LumberjackTabWidget.tscn
+++ b/Assets/UI/TabWidgets/LumberjackTabWidget.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://blbqmvav0vjgg"]
+[gd_scene load_steps=7 format=3 uid="uid://blbqmvav0vjgg"]
 
 [ext_resource type="PackedScene" uid="uid://bwtxisllq0ply" path="res://Assets/UI/TabWidgets/ProductionWithRelatedBuildingsMenuTabWidget.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://dg6whk6ygbtpi" path="res://Assets/UI/TabWidgets/ViewComponents/ProductionChain.tscn" id="3"]
+[ext_resource type="Resource" uid="uid://barkk28ae0v15" path="res://Assets/World/Data/ItemData/Wood.tres" id="4_j28ux"]
 [ext_resource type="Resource" uid="uid://c5xn4hbcdts6c" path="res://Assets/World/Data/ItemData/Timber.tres" id="4_pahp5"]
 [ext_resource type="Script" path="res://Assets/UI/TabWidgets/LumberjackTabWidget.gd" id="5"]
 [ext_resource type="PackedScene" uid="uid://bj3hi4dvcviuc" path="res://Assets/UI/TabWidgets/Buttons/ActionButton/ActionButtons/BuildButtons/BuildTreeButton.tscn" id="6"]
@@ -15,9 +16,7 @@ text = "Lumberjack"
 
 [node name="ProductionChain" parent="TabContainer/VBoxContainer" index="2" instance=ExtResource("3")]
 layout_mode = 2
-input_one_type = null
-input_two_type = null
-input_three_type = null
+input_two_type = ExtResource("4_j28ux")
 output_type = ExtResource("4_pahp5")
 
 [node name="MarginContainer" type="MarginContainer" parent="TabContainer/VBoxContainer" index="3"]
@@ -31,12 +30,3 @@ columns = 4
 
 [node name="BuildTreeAreaButton" parent="TabContainer/VBoxContainer/MarginContainer/GridContainer" index="0" instance=ExtResource("10")]
 layout_mode = 2
-
-[node name="MarginContainer" parent="TabContainer/BuildRelatedBuildings" index="1"]
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_right = 10
-
-[node name="BuildTreeButton" parent="TabContainer/BuildRelatedBuildings/MarginContainer/GridContainer" index="0" instance=ExtResource("6")]
-layout_mode = 2
-
-[editable path="WidgetDetail/Body/TabContainer/BuildRelatedBuildings"]

--- a/Assets/UI/TabWidgets/ViewComponents/ProductionChain.gd
+++ b/Assets/UI/TabWidgets/ViewComponents/ProductionChain.gd
@@ -43,17 +43,43 @@ func _ready():
 
 func _process(_delta):
   if self.owner.visible:
-    var selected_objects = self.owner.selected_objects
-    var progress: float = 0
-    if len(selected_objects) == 1:
-      var building = selected_objects[0]
-      if building.production_timer != null:
-        var production_time = building.building_data.processing_time
-        progress = (production_time - building.production_timer.time_left) / production_time
-    set_progress_bar(progress)
+    update_progress_bar()
+    update_resource_amount()
 
-## Sets the progress bar to the given progress, 0 to 1 
-func set_progress_bar(progress: float = 0):
+func update_resource_amount():
+  var input_resources = self.owner.selected_objects[0].input_product_storage
+  # get the amount of the input resources
+  var new_input_one_value = input_resources.get(input_one_type)
+  var new_input_two_value = input_resources.get(input_two_type)
+  var new_input_three_value = input_resources.get(input_three_type)
+  # if no resource of that type, set it to 0
+  if new_input_one_value == null:
+    new_input_one_value = 0
+  if new_input_two_value == null:
+    new_input_two_value = 0
+  if new_input_three_value == null:
+    new_input_three_value = 0
+  # set the input values
+  input_one_value = new_input_one_value
+  input_two_value = new_input_two_value
+  input_three_value = new_input_three_value
+  # set the input limits
+  var limit = self.owner.selected_objects[0].building_data.max_storage_capacity
+  input_one_storage_limit = limit
+  input_two_storage_limit = limit
+  input_three_storage_limit = limit
+  # set the output value and limit
+  output_value = self.owner.selected_objects[0].number_of_output_products
+  output_storage_limit = limit
+
+func update_progress_bar():
+  var selected_objects = self.owner.selected_objects
+  var progress: float = 0
+  if len(selected_objects) == 1:
+    var building = selected_objects[0]
+    if building.production_timer != null:
+      var production_time = building.building_data.processing_time
+      progress = (production_time - building.production_timer.time_left) / production_time
   progress_bar.size_flags_stretch_ratio = progress
   progress_bar_spacer.size_flags_stretch_ratio = 1 - progress
 
@@ -137,28 +163,28 @@ func set_input_one_storage_limit(new_input_one_storage_limit: int) -> void:
   if not is_inside_tree():
     await self.ready
 
-  input_one.storage_limit = input_one_storage_limit
+  input_one.limit = input_one_storage_limit
 
 func set_input_two_storage_limit(new_input_two_storage_limit: int) -> void:
   input_two_storage_limit = new_input_two_storage_limit
   if not is_inside_tree():
     await self.ready
 
-  input_two.storage_limit = input_two_storage_limit
+  input_two.limit = input_two_storage_limit
 
 func set_input_three_storage_limit(new_input_three_storage_limit: int) -> void:
   input_three_storage_limit = new_input_three_storage_limit
   if not is_inside_tree():
     await self.ready
 
-  input_three.storage_limit = input_three_storage_limit
+  input_three.limit = input_three_storage_limit
 
 func set_output_storage_limit(new_output_storage_limit: int) -> void:
   output_storage_limit = new_output_storage_limit
   if not is_inside_tree():
     await self.ready
 
-  output.storage_limit = output_storage_limit
+  output.limit = output_storage_limit
 
 func _set_input_one(enabled: bool) -> void:
   top_section.visible = enabled

--- a/Assets/World/Buildings/Lumberjack/Lumberjack/Lumberjack2D.gd
+++ b/Assets/World/Buildings/Lumberjack/Lumberjack/Lumberjack2D.gd
@@ -69,7 +69,7 @@ func movement_loop():
 func wait_for_tree_in_need():
 # wait until needs and can go to tree
   while true:
-    var wood_amount = building_parent.input_product_storage.get("wood")
+    var wood_amount = building_parent.input_product_storage.get(building_parent.wood_data)
     if wood_amount != null and closest_trees != []:
       if wood_amount < building_parent.building_data.max_storage_capacity:
         return

--- a/Assets/World/Buildings/Lumberjack/LumberjackTent2D.gd
+++ b/Assets/World/Buildings/Lumberjack/LumberjackTent2D.gd
@@ -2,11 +2,12 @@ extends ProductionBuilding2D
 
 class_name Lumberjack2D
 
+@export var wood_data: ItemData = preload("res://Assets/World/Data/ItemData/Wood.tres")
 @export var unload_wood_time: int = 2
 
 func _ready():
   self.setup_building()
-  self.input_product_storage["wood"] = 0
+  self.input_product_storage[wood_data] = 0
   production_loop()
 
 func production_loop():
@@ -20,18 +21,18 @@ func wait_for_storage_space():
     await self.get_tree().create_timer(1).timeout
 
 func wait_for_wood():
-  while self.input_product_storage["wood"] <= 0:
+  while self.input_product_storage[wood_data] <= 0:
     await self.get_tree().create_timer(1).timeout
 
 func produce_wood():
-  if self.input_product_storage["wood"] > 0:
+  if self.input_product_storage[wood_data] > 0:
     self.production_timer = self.get_tree().create_timer(self.building_data.processing_time)
     await self.production_timer.timeout
     self.production_timer = null
-    self.input_product_storage["wood"] -= 1
+    self.input_product_storage[wood_data] -= 1
     self.number_of_output_products += 1
     self.show_tooltip_animation(1) # fire and forget
 
 func unload_wood():
   await self.get_tree().create_timer(unload_wood_time).timeout
-  self.input_product_storage["wood"] += 1
+  self.input_product_storage[wood_data] += 1

--- a/Assets/World/Data/ItemData/Wood.tres
+++ b/Assets/World/Data/ItemData/Wood.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="ItemData" load_steps=3 format=3 uid="uid://barkk28ae0v15"]
+
+[ext_resource type="Texture2D" uid="uid://dof6fekq0by1d" path="res://Assets/UI/Icons/Resources/32/008.png" id="1_k06pm"]
+[ext_resource type="Script" path="res://Assets/World/Data/ItemData/ItemData.gd" id="2_r5t5d"]
+
+[resource]
+script = ExtResource("2_r5t5d")
+game_name = "Wood"
+icon = ExtResource("1_k06pm")


### PR DESCRIPTION
*Production chain displays the amount of resources in storage
*New item data: wood, so that the lumberjacks don`t use strings 
*Resource overlay stopping mouse fix

![image](https://github.com/user-attachments/assets/633039cb-fa54-46b7-b9a1-90d1acd3a6ff)